### PR TITLE
Refactor db to a single module, folder, conf value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 public/css
 node_modules
 local.json
+db/
+test/db/

--- a/index.js
+++ b/index.js
@@ -10,8 +10,6 @@ var services = require('./lib/services');
 var profile = require('./lib/profile');
 var auth = require('./lib/auth');
 
-auth.setDB();
-
 var posts = require('./lib/posts');
 var utils = require('./lib/utils');
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var Hapi = require('hapi');
-var nconf = require('nconf');
+var conf = require('./lib/conf');
 var Boom = require('boom');
 var Joi = require('joi');
 var SocketIO = require('socket.io');
@@ -18,13 +18,11 @@ var utils = require('./lib/utils');
 var chatUsers = {};
 var chatUserCount = 0;
 
-nconf.argv().env().file({ file: 'local.json' });
-
 var server = new Hapi.Server();
 
 server.connection({
-  host: nconf.get('domain'),
-  port: nconf.get('port')
+  host: conf.get('domain'),
+  port: conf.get('port')
 });
 
 server.views({
@@ -291,7 +289,7 @@ if (process.env.NODE_ENV !== 'test') {
 
 var options = {
   cookieOptions: {
-    password: nconf.get('cookie'),
+    password: conf.get('cookie'),
     isSecure: false
   }
 };

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -2,9 +2,9 @@
 
 var uuid = require('uuid');
 var Boom = require('boom');
-var nconf = require('nconf');
 var level = require('level');
 var ttl = require('level-ttl');
+var conf = require('./conf');
 
 var profile = require('./profile');
 var utils = require('./utils');
@@ -12,8 +12,6 @@ var ban = require('./ban');
 ban.setDB();
 var pin = require('./pin');
 var fixtures = require('../test/fixtures.json');
-
-nconf.argv().env().file({ file: 'local.json' });
 
 var db;
 
@@ -39,7 +37,7 @@ var addNewUser = function (uid, phone, request, reply) {
 };
 
 var checkAdmin = function (uid, request) {
-  if (nconf.get('ops').indexOf(uid) > -1) {
+  if (conf.get('ops').indexOf(uid) > -1) {
     request.session.set('op', true);
     return;
   }

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -2,26 +2,26 @@
 
 var uuid = require('uuid');
 var Boom = require('boom');
-var level = require('level');
-var ttl = require('level-ttl');
 var conf = require('./conf');
 
 var profile = require('./profile');
 var utils = require('./utils');
 var ban = require('./ban');
-ban.setDB();
 var pin = require('./pin');
 var fixtures = require('../test/fixtures.json');
 
-var db;
+var dbs = require('./db');
+var db = dbs.register('logins', { ttl: true });
+var profdb = dbs('profile');
+var bandb = dbs('bans');
 
 var addNewUser = function (uid, phone, request, reply) {
-  profile.db().put('uid!' + uid, phone, function (err) {
+  profdb.put('uid!' + uid, phone, function (err) {
     if (err) {
       return reply(Boom.wrap(err, 400));
     }
 
-    profile.db().put('user!' + phone, {
+    profdb.put('user!' + phone, {
       uid: uid,
       phone: phone,
       secondary: {}
@@ -52,18 +52,18 @@ var register = function (request, reply) {
 
   console.log('logging in ', phone);
 
-  profile.db().get('user!' + phone, function (err, user) {
+  profdb.get('user!' + phone, function (err, user) {
     if (err || !user) {
       // Test secondary phone first before assuming it is a new registration
-      profile.db().get('secondary!' + phone, function (err, primary) {
-        if (err || !primary) {
+      profdb.get('secondary!' + phone, function (err, primary) {
+        if (err ||  !primary) {
           // register new user
           var uid = uuid.v4();
           addNewUser(uid, phone, request, reply);
           return;
         }
 
-        profile.db().get('user!' + primary, function (err, user) {
+        profdb.get('user!' + primary, function (err, user) {
           if (err) {
             // This shouldn't happen at all since attaching a secondary phone to
             // a non-existent primary means the data is faulty.
@@ -84,13 +84,6 @@ var register = function (request, reply) {
       reply.redirect('/');
     }
   });
-};
-
-exports.setDB = function (dbPath) {
-  db = ttl(level(dbPath || './db/logins', {
-    createIfMissing: true,
-    valueEncoding: 'json'
-  }));
 };
 
 exports.login = function (request, reply) {
@@ -146,7 +139,7 @@ exports.login = function (request, reply) {
     });
   };
 
-  ban.db().get(ip, function (err, p) {
+  bandb.get(ip, function (err, p) {
     if (!err) {
       return reply(Boom.wrap(new Error('Your number has been banned. Please contact an operator.'), 400));
     }

--- a/lib/ban.js
+++ b/lib/ban.js
@@ -1,19 +1,6 @@
 'use strict';
 
-var level = require('level');
-
-var db;
-
-exports.setDB = function (dbPath) {
-  db = level(dbPath || './db/bans', {
-    createIfMissing: true,
-    valueEncoding: 'json'
-  });
-};
-
-exports.db = function () {
-  return db;
-};
+var db = require('./db').register('bans');
 
 exports.hammer = function (phone, next) {
   db.put(phone, phone, function (err) {

--- a/lib/conf.js
+++ b/lib/conf.js
@@ -1,0 +1,6 @@
+// Put this in a module so that it's only ever done one time.
+// Otherwise, settings get overwritten each time, making testing
+// harder.
+var nconf = require('nconf');
+nconf.argv().env().file({ file: 'local.json' });
+module.exports = nconf;

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var level = require('level');
+var ttl = require('level-ttl');
+var conf = require('./conf');
+var rimraf = require('rimraf');
+
+// Load this up once at startup.  Changing DB locations
+// mid-process is not supported.
+var path = conf.get('db') || './db';
+
+var dbs = {};
+var options = {};
+
+// Usage: db('pin') returns the pin db
+exports = module.exports = function db (key) {
+  if (!dbs[key]) {
+    throw new Error('Database not registered: ' + key);
+  }
+  return dbs[key];
+};
+
+exports.register = function (key, opt, fn) {
+  if (dbs[key]) {
+    throw new Error('Database already registered: ' + key);
+  }
+
+  var dbPath = path + '/' + key;
+  var db = level(dbPath, {
+    createIfMissing: true,
+    valueEncoding: 'json'
+  });
+
+  if (opt && opt.ttl) {
+    db = ttl(db);
+  }
+
+  dbs[key] = db;
+  options[key] = opt;
+
+  return db;
+};

--- a/lib/pin.js
+++ b/lib/pin.js
@@ -2,26 +2,11 @@
 
 var uuid = require('uuid');
 var Boom = require('boom');
-var level = require('level');
-var ttl = require('level-ttl');
 var twilio = require('./twilio');
 var conf = require('./conf');
 var fixtures = require('../test/fixtures.json');
 var client = twilio(conf.get('twilioSID'), conf.get('twilioToken'))
-
-// TODO(isaacs): factor out db stuff in a DRY way
-var db;
-exports.setDB = function (dbPath) {
-  db = ttl(level(dbPath || './db/pins', {
-    createIfMissing: true,
-    valueEncoding: 'json'
-  }));
-};
-exports.setDB();
-
-exports.db = function () {
-  return db;
-};
+var db = require('./db').register('pins');
 
 exports.verify = function (phone, pin, next) {
   if (process.env.NODE_ENV !== 'test' && process.env.npm_lifecycle_event !== 'dev') {

--- a/lib/pin.js
+++ b/lib/pin.js
@@ -2,16 +2,12 @@
 
 var uuid = require('uuid');
 var Boom = require('boom');
-var nconf = require('nconf');
 var level = require('level');
 var ttl = require('level-ttl');
 var twilio = require('./twilio');
-
+var conf = require('./conf');
 var fixtures = require('../test/fixtures.json');
-
-nconf.argv().env().file({ file: 'local.json' });
-
-var client = twilio(nconf.get('twilioSID'), nconf.get('twilioToken'));
+var client = twilio(conf.get('twilioSID'), conf.get('twilioToken'))
 
 // TODO(isaacs): factor out db stuff in a DRY way
 var db;
@@ -59,7 +55,7 @@ exports.generate = function (phone, next) {
 
     client.sendMessage({
       to: phone,
-      from: '+' + nconf.get('twilioNumber'),
+      from: '+' + conf.get('twilioNumber'),
       body: pin
     }, function (err) {
       console.error(err);
@@ -70,6 +66,5 @@ exports.generate = function (phone, next) {
 
       next(null, true);
     });
-
   });
 };

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var level = require('level');
 var Boom = require('boom');
 var concat = require('concat-stream');
 var moment = require('moment');
@@ -12,22 +11,10 @@ var utils = require('./utils');
 
 var MAX_POSTS = 10;
 
-var db;
-exports.setDB = function (dbPath) {
-  db = level(dbPath || './db/posts', {
-    createIfMissing: true,
-    valueEncoding: 'json'
-  });
-};
-
-exports.setDB();
+var db = require('./db').register('posts');
 
 var getTime = function () {
   return Math.floor(Date.now() / 1000);
-};
-
-exports.db = function () {
-  return db;
 };
 
 exports.add = function (request, reply) {

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -4,13 +4,11 @@ var level = require('level');
 var Boom = require('boom');
 var concat = require('concat-stream');
 var moment = require('moment');
-var nconf = require('nconf');
+var conf = require('./conf');
 
 var crypto = require('crypto');
 var services = require('./services');
 var utils = require('./utils');
-
-nconf.argv().env().file({ file: 'local.json' });
 
 var MAX_POSTS = 10;
 
@@ -156,7 +154,7 @@ exports.getAllRecent = function (request, reply) {
         firstKey: firstKey,
         lastKey: lastKey,
         next: (streamOpt.finalKey !== lastKey),
-        analytics: nconf.get('analytics'),
+        analytics: conf.get('analytics'),
         session: request.session.get('uid'),
         posts: posts.map(function (post) {
           post.value.created = setDate(post.value.created);
@@ -258,7 +256,7 @@ exports.getRecent = function (request, reply) {
         firstKey: firstKey,
         lastKey: lastKey,
         next: (streamOpt.finalKey !== lastKey),
-        analytics: nconf.get('analytics'),
+        analytics: conf.get('analytics'),
         session: uid,
         posts: posts
       });
@@ -333,7 +331,7 @@ exports.get = function (request, reply) {
     post.created = setDate(post.created);
 
     reply.view('post', {
-      analytics: nconf.get('analytics'),
+      analytics: conf.get('analytics'),
       id: request.params.key,
       session: request.session.get('uid') || false,
       op: request.session.get('op'),

--- a/lib/profile.js
+++ b/lib/profile.js
@@ -3,7 +3,8 @@
 var level = require('level');
 var Boom = require('boom');
 var concat = require('concat-stream');
-var nconf = require('nconf');
+var conf = require('./conf');
+
 
 var services = require('./services');
 var posts = require('./posts');
@@ -11,7 +12,6 @@ var utils = require('./utils');
 var ban = require('./ban');
 var pin = require('./pin');
 
-nconf.argv().env().file({ file: 'local.json' });
 
 var db;
 exports.setDB = function (dbPath) {
@@ -98,10 +98,10 @@ exports.getAllUsers = function (request, reply) {
 
   rs.pipe(concat(function (users) {
     return reply.view('users', {
-      analytics: nconf.get('analytics'),
+      analytics: conf.get('analytics'),
       session: request.session.get('uid') || false,
       users: users.map(function (user) {
-        if (nconf.get('ops').indexOf(user.value.uid) > -1) {
+        if (conf.get('ops').indexOf(user.value.uid) > -1) {
           user.op = true;
         }
 
@@ -265,7 +265,7 @@ exports.addPhone = function (request, reply) {
           }
 
           var ctx = {
-            analytics: nconf.get('analytics'),
+            analytics: conf.get('analytics'),
             phone: phone,
             user: user
           };

--- a/lib/profile.js
+++ b/lib/profile.js
@@ -1,30 +1,19 @@
 'use strict';
 
-var level = require('level');
 var Boom = require('boom');
 var concat = require('concat-stream');
 var conf = require('./conf');
 
+var dbs = require('./db');
+var db = dbs.register('profile');
+
+var posts = require('./posts');
+var postdb = dbs('posts');
 
 var services = require('./services');
-var posts = require('./posts');
 var utils = require('./utils');
 var ban = require('./ban');
 var pin = require('./pin');
-
-
-var db;
-exports.setDB = function (dbPath) {
-  db = level(dbPath || './db/profile', {
-    createIfMissing: true,
-    valueEncoding: 'json'
-  });
-};
-exports.setDB();
-
-exports.db = function () {
-  return db;
-};
 
 exports.update = function (request, reply) {
   var phone = request.session.get('phone');
@@ -148,7 +137,7 @@ var deletePostsAndUser = function (all, user, next) {
     });
   });
 
-  posts.db().batch(batch, function (err) {
+  postdb.batch(batch, function (err) {
     if (err) {
       return next(err);
     }

--- a/lib/services.js
+++ b/lib/services.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var nconf = require('nconf');
+var conf = require('./conf');
 var Boom = require('boom');
 
 var profile = require('./profile');
@@ -8,16 +8,14 @@ var posts = require('./posts');
 var ban = require('./ban');
 var utils = require('./utils');
 
-nconf.argv().env().file({ file: 'local.json' });
-
 var ctx = {
-  analytics: nconf.get('analytics')
+  analytics: conf.get('analytics')
 };
 
 exports.home = function (request, reply) {
   ctx.error = request.query.err || '';
   ctx.session = request.session.get('uid') || false;
-  ctx.ops = nconf.get('ops') || {};
+  ctx.ops = conf.get('ops') || {};
 
   if (ctx.ops.length > 0) {
     var count = 0;
@@ -90,7 +88,7 @@ exports.user = function (request, reply) {
         posts: opts.posts,
         phone: request.session.get('op') ? user.phone : false,
         op: request.session.get('op'),
-        userOp: nconf.get('ops').indexOf(user.uid) > -1 || false
+        userOp: conf.get('ops').indexOf(user.uid) > -1 || false
       });
     });
   };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var level = require('level');
-var ttl = require('level-ttl');
 var twitter = require('twitter-text');
 var concat = require('concat-stream');
 var Boom = require('boom');
@@ -9,6 +7,7 @@ var Boom = require('boom');
 var profile = require('./profile');
 var fixtures = require('../test/fixtures.json');
 
+var profiledb = require('./db')('profile');
 
 exports.merge = function (objA, objB) {
   for (var key in objB) {
@@ -21,7 +20,7 @@ exports.merge = function (objA, objB) {
 
 exports.fixNames = function (request, reply) {
   // Shouldn't happen but when it does, a quick way to force a name on one that doesn't exist in an account
-  var rs = profile.db().createReadStream({
+  var rs = profiledb.createReadStream({
     gte: 'user!',
     lte: 'user!\xff'
   });
@@ -31,7 +30,7 @@ exports.fixNames = function (request, reply) {
       if (!user.value.name) {
         user.value.name = '???';
       }
-      profile.db().put(user.key, user.value);
+      profiledb.put(user.key, user.value);
     });
 
     reply.redirect('/');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var level = require('level');
-var nconf = require('nconf');
 var ttl = require('level-ttl');
 var twitter = require('twitter-text');
 var concat = require('concat-stream');
@@ -10,7 +9,6 @@ var Boom = require('boom');
 var profile = require('./profile');
 var fixtures = require('../test/fixtures.json');
 
-nconf.argv().env().file({ file: 'local.json' });
 
 exports.merge = function (objA, objB) {
   for (var key in objB) {

--- a/local.json-dist
+++ b/local.json-dist
@@ -6,5 +6,6 @@
     "twilioSID": "<sid>",
     "twilioToken": "<auth token>",
     "twilioNumber": "15555555555",
-    "ops": ["<uid>"]
+    "ops": ["<uid>"],
+    "db": "./db"
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "eslint": "^0.10.2",
     "lab": "~5.1.1",
     "nock": "~0.52.4",
-    "nodemon": "~1.2.1"
+    "nodemon": "~1.2.1",
+    "rimraf": "^2.2.8"
   },
   "repository": {
     "type": "git",

--- a/test/db/.gitignore
+++ b/test/db/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/test/test.js
+++ b/test/test.js
@@ -19,6 +19,15 @@ process.env.NODE_ENV = 'test';
 var testdb = './test/db';
 var conf = require('../lib/conf');
 conf.set('db', testdb);
+conf.set('cookie', 'testsecret');
+
+// Set a different port than the "default", so it doesn't break
+// as often if you're running a dev server and tests together.
+var PORT = process.env.PORT || 8000;
+conf.set('port', PORT);
+var DOMAIN = process.env.DOMAIN || 'localhost';
+conf.set('domain', DOMAIN);
+var HOST = DOMAIN + ':' + PORT;
 
 var rimraf = require('rimraf');
 var resetDB = function () {
@@ -289,7 +298,7 @@ lab.test('make a response post', function (done) {
       cookie: cookieHeader()
     },
     payload: {
-      reply: 'http://localhost:3000/post/post!' + post,
+      reply: 'http://' + HOST  + '/post/post!' + post,
       content: 'Reply forthwith',
       fuzziewuzzywasabear: 'some fuzes fore goode measuries'
     }

--- a/test/test.js
+++ b/test/test.js
@@ -15,23 +15,34 @@
 
 process.env.NODE_ENV = 'test';
 
-var child = require('child_process');
+// Have to do this first so that db's get set up in the test folder.
+var testdb = './test/db';
+var conf = require('../lib/conf');
+conf.set('db', testdb);
+
+var rimraf = require('rimraf');
+var resetDB = function () {
+  // delete the test DBs
+  rimraf.sync(testdb);
+  require('fs').mkdirSync(testdb);
+};
+
+// Reset the db's now.  Must be done *before* loading the app
+// or else leveldb will freak out.
+resetDB();
+
+
+var db = require('../lib/db');
+
 var Lab = require('lab');
 var Code = require('code');
 
 var lab = exports.lab = Lab.script();
 
 var fixtures = require('./fixtures.json');
-var server = require('../').getServer();
 
-var posts = require('../lib/posts');
-posts.setDB('./test/db/posts');
-var auth = require('../lib/auth');
-auth.setDB('./test/db/logins');
-var ban = require('../lib/ban');
-ban.setDB('./test/db/bans');
-var profile = require('../lib/profile');
-profile.setDB('./test/db/profile');
+// Now load up the server itself.
+var server = require('../').getServer();
 
 // Not a very smart cookie jar, but good enough for this purpose
 var deliciousDelicacies = {};
@@ -54,20 +65,11 @@ var cookieHeader = function () {
   return ch;
 };
 
-var resetDB = function (next) {
-  child.exec('rm -rf ./test/db/*', function () {
-    next();
-  });
-};
 
-// Initialization before any tests are run
-lab.before(function (done) {
-  resetDB(done);
-});
-
-// Cleanup after all tests are finished
+// once tests are done, delete test db.
 lab.after(function (done) {
-  resetDB(done);
+  resetDB();
+  done();
 });
 
 lab.test('successful authentication by phone number generates a PIN', function (done) {
@@ -112,13 +114,14 @@ lab.test('unsuccessful authentication by multiple login attempts', function (don
         count ++;
       } else {
         Code.expect(response.headers.location).to.equal('/login?err=Your+number+has+been+banned.+Please+contact+an+operator.');
-        resetDB(done);
+        require('../lib/ban').unhammer(fixtures.phone, done);
       }
     });
   };
 
   postLogin();
 });
+
 
 lab.test('log in with valid pin', function (done) {
   var options = {
@@ -140,6 +143,7 @@ lab.test('log in with valid pin', function (done) {
   });
 });
 
+
 lab.test('authenticate with an invalid PIN', function (done) {
   var options = {
     method: 'POST',
@@ -152,7 +156,7 @@ lab.test('authenticate with an invalid PIN', function (done) {
   server.inject(options, function (response) {
     Code.expect(response.statusCode).to.equal(302);
     Code.expect(response.headers.location).to.equal('/authenticate?err=Invalid+pin');
-    resetDB(done);
+    done();
   });
 });
 


### PR DESCRIPTION
The better to override in tests, and DRY up a bunch of duplicated code.

It feels like lib/db.js should be some kind of dedicated "manage
multiple levelDBs in a single folder" module or something, but there's a
lot of BBS-specific stuff in there.  I'm not level-savvy enough to
confidently predict what other users might want in such a module, so I'm
tempted to just leave it as-is for the next brave soul to figure out.

Configuring the location of the db root folder is super important,
though.  Now, you could very easily start the server with something like
`node index.js --db /var/db/bbs` (or env or local.json) and it'll put
all the levels in there.  For tests, this makes it easy to wipe the db's
out and not accidentally the non-test databases.

Fixes #67
