### PR TITLE
Fix: Don't delete other users' posts when deleting a user account

### DIFF
--- a/lib/posts.js
+++ b/lib/posts.js
@@ -186,9 +186,11 @@ exports.getAllByUser = function (uid, next) {
     }
 
     posts.forEach(function (post) {
+      var postid = post.key.split('!')[2];
+
       var fs = db.createReadStream({
-        gte: 'post!' + post.value.created,
-        lte: 'post!' + post.value.created + '\xff'
+        gte: 'post!' + postid,
+        lte: 'post!' + postid + '\xff'
       });
 
       fs.pipe(concat(function (feed) {


### PR DESCRIPTION
Previously this deleted all posts with the same creation time as the
user's posts.