### PR TITLE
Add posts export (Fixes GH-98)

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,6 +134,11 @@ var routes = [
     handler: services.profile
   },
   {
+    method: 'GET',
+    path: '/profile/export.{ext}',
+    handler: profile.exportPosts
+  },
+  {
     method: 'POST',
     path: '/profile',
     handler: profile.update,
@@ -229,7 +234,8 @@ server.ext('onPreResponse', function (request, reply) {
   var response = request.response;
   if (!response.isBoom) {
     if (['/profile', '/messages', '/chat', '/posts', '/links', '/users',
-         '/deleteaccount', '/post'].indexOf(request.path) > -1) {
+         '/deleteaccount', '/post', '/profile/export.json',
+         '/profile/export.csv'].indexOf(request.path) > -1) {
       if (!request.session.get('uid')) {
         return reply.redirect('/');
       }

--- a/lib/profile.js
+++ b/lib/profile.js
@@ -282,3 +282,55 @@ exports.addPhone = function (request, reply) {
     }
   });
 };
+
+exports.exportPosts = function (request, reply) {
+  posts.getAllByUser(request.session.get('uid'), function (err, all) {
+    if (err) {
+      return reply(err);
+    }
+
+    var posts = all.posts.map(function (post) {
+      // old posts don't have a postid
+      // however, they used to use the timestamp as an id,
+      // so we can map it to that
+      if (!post.value.postid) {
+        post.value.postid = String(post.value.created);
+      }
+      return post.value;
+    });
+
+    if (request.params.ext === 'csv') {
+      // get all possible keys
+      // this ensures we get all possible keys, even if new
+      // fields are added to posts later
+      var keys = [];
+      posts.forEach(function (post) {
+        Object.keys(post).forEach(function (key) {
+          if (keys.indexOf(key) === -1) {
+            keys.push(key);
+          }
+        });
+      });
+
+      // add values
+      // this makes sure that if new fields are added to posts later,
+      // old posts will still export properly
+      var vals = [];
+      posts.forEach(function (post) {
+        var val = [];
+        Object.keys(post).forEach(function (key) {
+          var i = keys.indexOf(key);
+          val[i] = post[key];
+        });
+
+        vals.push(val.join(','));
+      });
+
+      // generate output
+      var csv = keys.join(',') + '\n' + vals.join('\n');
+      reply(csv).type('text/csv');
+    } else {
+      reply(posts);
+    }
+  });
+};

--- a/package.json
+++ b/package.json
@@ -32,11 +32,12 @@
   },
   "devDependencies": {
     "code": "~1.2.1",
+    "csv-parse": "0.0.6",
+    "eslint": "^0.10.2",
     "gulp": "^3.8.10",
     "gulp-concat": "^2.4.3",
     "gulp-nodemon": "^1.0.4",
     "gulp-stylus": "^1.3.4",
-    "eslint": "^0.10.2",
     "lab": "~5.1.1",
     "nock": "~0.52.4",
     "nodemon": "~1.2.1",

--- a/views/profile.jade
+++ b/views/profile.jade
@@ -31,6 +31,12 @@ block content
   for number in user.secondary
     p= user.secondary[number]
 
+  h2 export posts
+
+  a(href='/profile/export.json') .json
+  | &#xa0;
+  a(href='/profile/export.csv') .csv
+
   if (op && !userOp)
     h2.delete-account Delete account
     p If you delete this account, all posts associated with this will be removed.


### PR DESCRIPTION
This adds the routes `/profile/export.json` and `/profile/export.csv`. They export the current user's posts in the respective format. Includes tests! :sparkles: 