### PR TITLE
removed package 'nock' from devDependecies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,3 +1,4 @@
+
 {
   "name": "bigboringsystem",
   "version": "1.0.0",
@@ -38,7 +39,6 @@
     "gulp-stylus": "^1.3.4",
     "eslint": "^0.10.2",
     "lab": "~5.1.1",
-    "nock": "~0.52.4",
     "nodemon": "~1.2.1",
     "rimraf": "^2.2.8"
   },


### PR DESCRIPTION
it was included in commit [440360e](https://github.com/joates/bigboringsystem/commit/440360e020f85d4d240e338abd33f88f266f9c37#diff-b9cfc7f2cdf78a7f4b91a753d10865a2) but is not currently used in tests.