### PR TITLE
Remove default for ops

### DIFF
--- a/local.json-dist
+++ b/local.json-dist
@@ -6,6 +6,6 @@
     "twilioSID": "<sid>",
     "twilioToken": "<auth token>",
     "twilioNumber": "15555555555",
-    "ops": ["<uid>"],
+    "ops": [],
     "db": "./db"
 }


### PR DESCRIPTION
IMO it's confusing to have a sample operator by default, since this line will evaluate to true and cause weird issues on first time run: https://github.com/bigboringsystem/bigboringsystem/blob/master/lib/services.js#L20

This way, `npm start` will actually run properly locally after adding Twilio credentials