### PR TITLE
Fix #111: Prevent blank posts

### DIFF
--- a/lib/posts.js
+++ b/lib/posts.js
@@ -30,6 +30,11 @@ exports.add = function (request, reply) {
     return reply.redirect('/profile');
   }
 
+  if (!request.payload.content) {
+    var err = new Error('You must include content with your post');
+    return reply(Boom.wrap(err, 400));
+  }
+
   var postItem = {
     uid: uid,
     name: name,

--- a/views/posts.jade
+++ b/views/posts.jade
@@ -7,7 +7,7 @@ block content
     label(for='reply') reply links to previous posts? (space delimited)
       input(type='text', name='reply')
     label(for='content') content
-      textarea(rows='10', cols='90', name='content')
+      textarea(rows='10', cols='90', name='content', required)
     if error
       p.error= error
     input(type='hidden', name='crumb', value='#{crumb}')


### PR DESCRIPTION
I noticed that the error message page doesn't actually display error messages, but perhaps that should be a new ticket?