### PR TITLE
Add linting to CI / Testing

### DIFF
--- a/.eslintrc-frontend
+++ b/.eslintrc-frontend
@@ -1,0 +1,9 @@
+{
+	"env": {
+		"browser": true
+	},
+	"rules": {
+		"quotes": [2, "single"],
+		"no-unused-vars": [1]
+	}
+}

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -56,7 +56,7 @@ var register = function (request, reply) {
     if (err || !user) {
       // Test secondary phone first before assuming it is a new registration
       profdb.get('secondary!' + phone, function (err, primary) {
-        if (err ||  !primary) {
+        if (err || !primary) {
           // register new user
           var uid = uuid.v4();
           addNewUser(uid, phone, request, reply);

--- a/lib/pin.js
+++ b/lib/pin.js
@@ -5,7 +5,7 @@ var Boom = require('boom');
 var twilio = require('./twilio');
 var conf = require('./conf');
 var fixtures = require('../test/fixtures.json');
-var client = twilio(conf.get('twilioSID'), conf.get('twilioToken'))
+var client = twilio(conf.get('twilioSID'), conf.get('twilioToken'));
 var db = require('./db').register('pins');
 
 exports.verify = function (phone, pin, next) {

--- a/lib/profile.js
+++ b/lib/profile.js
@@ -289,7 +289,7 @@ exports.exportPosts = function (request, reply) {
       return reply(err);
     }
 
-    var posts = all.posts.map(function (post) {
+    var sanitizedPosts = all.posts.map(function (post) {
       // old posts don't have a postid
       // however, they used to use the timestamp as an id,
       // so we can map it to that
@@ -304,7 +304,7 @@ exports.exportPosts = function (request, reply) {
       // this ensures we get all possible keys, even if new
       // fields are added to posts later
       var keys = [];
-      posts.forEach(function (post) {
+      sanitizedPosts.forEach(function (post) {
         Object.keys(post).forEach(function (key) {
           if (keys.indexOf(key) === -1) {
             keys.push(key);
@@ -316,7 +316,7 @@ exports.exportPosts = function (request, reply) {
       // this makes sure that if new fields are added to posts later,
       // old posts will still export properly
       var vals = [];
-      posts.forEach(function (post) {
+      sanitizedPosts.forEach(function (post) {
         var val = [];
         Object.keys(post).forEach(function (key) {
           var i = keys.indexOf(key);
@@ -330,7 +330,7 @@ exports.exportPosts = function (request, reply) {
       var csv = keys.join(',') + '\n' + vals.join('\n');
       reply(csv).type('text/csv');
     } else {
-      reply(posts);
+      reply(sanitizedPosts);
     }
   });
 };

--- a/lib/twilio.js
+++ b/lib/twilio.js
@@ -1,3 +1,4 @@
+/*eslint no-process-exit: 0 */
 'use strict';
 
 var twilio = require('twilio');
@@ -5,25 +6,23 @@ var mock = function () {
   return {
     sendMessage: function (options, next) { next(); }
   };
-}
+};
+
 var isTest = process.env.NODE_ENV === 'test';
 var isDev = process.env.npm_lifecycle_event === 'dev';
 
 if (isTest || isDev) {
-  
   module.exports = mock;
-  return;
-
 }
 
-module.exports = function (sid, token) {
+else {
+  module.exports = function (sid, token) {
 
-  if (!sid || !token) {
-    console.error('\nTwilio Not Configured:')
-    console.error('Please add twilioSID and twilioToken to your local.json config or else use `npm run dev` to run a local dev server instead\n');
-    process.exit();
-  }
-
-  return twilio(sid, token);
-
+    if (!sid || !token) {
+      console.error('\nTwilio Not Configured:');
+      console.error('Please add twilioSID and twilioToken to your local.json config or else use `npm run dev` to run a local dev server instead\n');
+      process.exit();
+    }
+    return twilio(sid, token);
+  };
 }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
   "scripts": {
     "start": "gulp",
     "dev": "gulp",
-    "test": "lab",
-    "lint": "eslint lib/"
+    "test": "npm run lint -s && lab",
+    "lint": "npm run lint-server && npm run lint-frontend",
+    "lint-server": "eslint lib/",
+    "lint-frontend": "eslint -c .eslintrc-frontend public/js"
   },
   "dependencies": {
     "crumb": "~4.0.0",

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -1,3 +1,4 @@
+/*global io */
 'use strict';
 
 (function () {
@@ -5,6 +6,8 @@
   var count = 0;
   var getChatSessionStorage = window.sessionStorage.getItem('chat');
   var chatEl = document.getElementById('chat');
+
+  var httpRequest = new XMLHttpRequest();
 
   var setUser = function () {
     if (httpRequest.readyState === 4) {
@@ -35,21 +38,25 @@
 
       time = '[' + hours + ':' + minutes + ':' + seconds + '] ';
     }
-    p.innerHTML = '<span class="timestamp">'+(time ? time : '')+'</span>' + '<strong>'+data.name+'</strong>' + ': ' + data.message;
+    p.innerHTML = '<span class="timestamp">' + (time ? time : '') + '</span>' + '<strong>' + data.name + '</strong>' + ': ' + data.message;
     var shouldScroll = (chatEl.scrollHeight - chatEl.scrollTop === chatEl.clientHeight);
     chatEl.appendChild(p);
     if (shouldScroll) {
       p.scrollIntoView();
     }
-    count ++;
+    count++;
 
     if (count > 100) {
       chatEl.removeChild(chatEl.getElementsByTagName('p')[0]);
-      count --;
+      count--;
     }
   };
 
-  var httpRequest = new XMLHttpRequest();
+  function getUserData() {
+    httpRequest.onreadystatechange = setUser;
+    httpRequest.open('GET', '/user');
+    httpRequest.send();
+  }
 
   getUserData();
 
@@ -57,12 +64,6 @@
     JSON.parse(getChatSessionStorage).forEach( function (data) {
       setChatMessage(data);
     });
-  }
-
-  function getUserData() {
-    httpRequest.onreadystatechange = setUser;
-    httpRequest.open('GET', '/user');
-    httpRequest.send();
   }
 
   document.getElementById('chat-form').onsubmit = function (event) {

--- a/public/js/global.js
+++ b/public/js/global.js
@@ -1,3 +1,4 @@
+/*global io */
 'use strict';
 
 (function () {
@@ -9,9 +10,9 @@
   if (getChatSessionStorage){
     JSON.parse(getChatSessionStorage).forEach( function (data) {
       chatArr.push(data);
-      count ++;
+      count++;
       if (count > 100) {
-        count --;
+        count--;
         chatArr.shift();
       }
     });


### PR DESCRIPTION
This patch closes #117 

It adds an npm script to lint the front end code in ```public/js```.  It also adds the linting step to ```npm test```.  Now linting will be part of the travis CI process, and all code will be nice and tidy.