### PR TITLE
Better pin info for users in dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,13 @@ Then start the server:
 
 Visit http://localhost:3000 in your browser.
 
-#### Development Setup
+## Development Setup
 
-If you are trying to set up b.b.s. for local development only, you can use `npm run dev` instead of `npm start` to bypass certain requirements. For instance, you won't need to set up Twilio credentials at all and you won't even need to have a local.json file--it'll just use some simple defaults if you don't create one.
+If you are trying to set up b.b.s. for local development only, you can use `npm run dev` instead of `npm start` to bypass certain requirements. For instance:
+
+* You won't need to set up Twilio credentials at all
+* In fact, you don't even need to have a local.json file. Dev mode will just use some simple defaults if you don't create one.
+* To log into the system, you can go directly to /authenticate and type in the PIN that's listed on the page for you. Or enter a valid-looking phone number on the home page to get to /authenticate, but you'll always use the listed dummy dev PIN.
 
 ## Ops
 

--- a/lib/conf.js
+++ b/lib/conf.js
@@ -6,7 +6,8 @@ nconf.argv().env().file({ file: 'local.json' });
 
 nconf.defaults({
   port: 3000,
-  cookie: 'secret'
+  cookie: 'secret',
+  ops: []
 });
 
 module.exports = nconf;

--- a/lib/pin.js
+++ b/lib/pin.js
@@ -30,7 +30,6 @@ exports.verify = function (phone, pin, next) {
 
 exports.generate = function (phone, next) {
   var pin = Math.floor(Math.random() * (10000 - 1111 + 1) + 1111);
-  console.log(pin);
 
   // 5 minutes max TTL
   db.put('pin!' + phone, pin, { ttl: 300000 }, function (err) {
@@ -43,9 +42,9 @@ exports.generate = function (phone, next) {
       from: '+' + conf.get('twilioNumber'),
       body: pin
     }, function (err) {
-      console.error(err);
 
       if (err) {
+        console.error(err);
         return next(Boom.wrap(new Error(err.message), err.status));
       }
 

--- a/lib/services.js
+++ b/lib/services.js
@@ -7,6 +7,7 @@ var profile = require('./profile');
 var posts = require('./posts');
 var ban = require('./ban');
 var utils = require('./utils');
+var fixtures = require('../test/fixtures');
 
 var ctx = {
   analytics: conf.get('analytics')
@@ -61,6 +62,7 @@ exports.chat = function (request, reply) {
 
 exports.authenticate = function (request, reply) {
   reply.view('authenticate', {
+    testPin: fixtures.pin,
     error: request.query.err
   });
 };

--- a/views/authenticate.jade
+++ b/views/authenticate.jade
@@ -1,5 +1,16 @@
 extend layout
 
+block content
+  h1 check your phone
+
+  if (process.env.npm_lifecycle_event === 'dev')
+    p
+      strong Development Mode: 
+      span= 'Use ' + testPin + ' to login'
+
+  else
+    p Enter the 4-digit PIN from your phone to log in.
+
 block login
   form(method='post', action='/authenticate')
     input(type='text', name='pin', autocomplete='off', required)
@@ -7,8 +18,4 @@ block login
       p.error= error
     input(type='hidden', name='crumb', value='#{crumb}')
     button(type='submit') log in
-
-block content
-  h1 check your phone
-
-  p Enter the 4-digit PIN from your phone to log in.
+    

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -36,13 +36,17 @@ html
         block login
           if !session
             form(method='post', action='/login')
-              p Enter your number without spaces or dashes
-              p You may need to prepend with + for non-U.S/Canadian numbers
+              if (process.env.npm_lifecycle_event === 'dev')
+                p Development Mode: Enter any valid phone number (no text will be sent)
+              else
+                p Enter your number without spaces or dashes
+                p You may need to prepend with + for non-U.S/Canadian numbers
               input(type='tel', name='phone', required)
               if error
                 p.error= error
               input(type='hidden', name='crumb', value='#{crumb}')
               button(type='submit') send my PIN
+
         block footer
           .footer
             p Powered by&#xa0;


### PR DESCRIPTION
This solves a few issues:

1. A bug introduced in my earlier PR that won't let you log in without an ops array as a default value
1. Removes the pin being output to the console on generation, since that was for dev mode and we now just check against the fixture pin
1. Easier for people to get it up and running with dev mode messages (see below images)

Homepage: http://cl.ly/image/440u36162b3K
Login with pin page: http://cl.ly/image/1I1o0s2q3S36