### PR TITLE
Remove for attributes from labels

### DIFF
--- a/views/posts.jade
+++ b/views/posts.jade
@@ -4,9 +4,9 @@ block content
   h1 my posts
 
   form(method='post', action='/post')
-    label(for='reply') reply links to previous posts? (space delimited)
+    label reply links to previous posts? (space delimited)
       input#reply-to(type='text', name='reply')
-    label(for='content') content
+    label content
       textarea(rows='10', cols='90', name='content', required)
     if error
       p.error= error

--- a/views/profile.jade
+++ b/views/profile.jade
@@ -8,20 +8,20 @@ block content
   form(method='post', action='/profile')
     if error
       p.error= error
-    label(for='name') name*
+    label name*
       input(type='text', name='name', value='#{user && user.name ? user.name : ""}', required)
-    label(for='websites') websites (space delimited)
+    label websites (space delimited)
       input(type='text', name='websites', value='#{user && user.websites ? user.websites : ""}')
-    label(for='bio') bio
+    label bio
       textarea(rows='5', cols='50', name='bio')= (user && user.bio ? user.bio : "")
     input(type='hidden', name='crumb', value='#{crumb}')
     button(type='submit') save
 
   form(method='post', action='/add_phone')
-    label(for='phone') add a second phone number to this account
+    label add a second phone number to this account
       input(type='tel', name='phone', value='#{phone}')
     if phone
-      label(for='pin') enter the PIN sent to your secondary phone for validation
+      label enter the PIN sent to your secondary phone for validation
         input(type='text', name='pin')
     input(type='hidden', name='crumb', value='#{crumb}')
     button(type='submit') add


### PR DESCRIPTION
The label tags on forms all had 'for' attribs, but there weren't any IDs
on the form elements.

Another approach would be to add 'id' attributes on all of the form
elements.  But since the form elements are children of their associated
labels, it's not necessary.