### PR TITLE
Show replies beneath post

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,6 +211,11 @@ var routes = [
     handler: posts.del
   },
   {
+    method: 'POST',
+    path: '/reply/{key}',
+    handler: posts.delReply
+  },
+  {
     method: 'GET',
     path: '/fixnames',
     handler: utils.fixNames

--- a/index.js
+++ b/index.js
@@ -153,7 +153,8 @@ var routes = [
         payload: {
           name: Joi.string().min(2).max(30),
           websites: Joi.string().allow(''),
-          bio: Joi.string().allow('')
+          bio: Joi.string().allow(''),
+          showreplies: Joi.string().allow('')
         }
       }
     }

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -149,7 +149,7 @@ exports.add = function (request, reply) {
       htmlEscapeNonEntities: true,
       targetBlank: true
     }),
-    showreplies: request.payload.showreply === 'on'
+    showreplies: request.payload.showreplies === 'on'
   };
 
   var postid = time + '-' + crypto.randomBytes(1).toString('hex');

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -154,6 +154,8 @@ var saveReply = function (postItem, next) {
     // content and replies get big.  We just need a few basics.
     // TODO(isaacs): Look up target post to make sure it's valid.
     // TODO(isaacs): put target UID on this object for moderation privs.
+    // TODO(isaacs): don't create if author is muted by target author
+    // TODO(isaacs): don't create if target is closed to replies
     var replyItem = {
       uid: postItem.uid,
       name: postItem.name,

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -43,8 +43,6 @@ var getInternalLinks = function (reply, host) {
     if (u.host === host) {
       // internal link.  Just save the postid.
       return parsed[1].replace(/^(post!|user![^!]+!)(.*)$/, '$2');
-    } else {
-      console.error('not an internal link host=%j u=%j', host, u);
     }
 
     return false;
@@ -158,7 +156,9 @@ var saveReply = function (postItem, next) {
     var replyItem = {
       uid: postItem.uid,
       name: postItem.name,
-      created: postItem.created
+      created: postItem.created,
+      postid: postid,
+      target: target
     };
 
     db.get('post!' + target, function (err, targetPost) {
@@ -502,6 +502,9 @@ exports.get = function (request, reply) {
       }
 
       post.replies = replies;
+      replies.forEach(function (reply) {
+        reply.created = setDate(reply.created);
+      });
 
       reply.view('post', {
         analytics: conf.get('analytics'),
@@ -523,7 +526,6 @@ var getReplyPosts = function (post, next) {
   };
 
   var replies = [];
-  var repliesraw = [];
   var rs = db.createReadStream(streamOpt);
 
   rs.on('data', function (reply) {
@@ -535,17 +537,11 @@ var getReplyPosts = function (post, next) {
     reply = reply[1];
     if (!reply) return;
 
-    repliesraw.push(reply);
-
-    var html = '\n<a href="/post/post!' + reply + '" rel="nofollow">' +
-      setDate(val.created) + '</a> - ' +
-      '<a href="/user/' + val.uid + '">' + val.name + '</a>';
-
-    replies.push(html);
+    replies.push(val);
   });
 
   rs.on('end', function () {
-    next(null, replies.join(''), repliesraw);
+    next(null, replies);
   });
 
   rs.on('error', next);

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -82,7 +82,8 @@ exports.add = function (request, reply) {
     content: utils.autoLink(request.payload.content, {
       htmlEscapeNonEntities: true,
       targetBlank: true
-    })
+    }),
+    showreplies: request.payload.showreply === 'on'
   };
 
   var postid = time + '-' + crypto.randomBytes(1).toString('hex');
@@ -164,6 +165,11 @@ var saveReply = function (postItem, next) {
     db.get('post!' + target, function (err, targetPost) {
       if (err) {
         // invalid replyto.  skip, and mark for deletion once we're done.
+        postItem.replyto[index] = false;
+        return then();
+      }
+
+      if (!targetPost.showreplies) {
         postItem.replyto[index] = false;
         return then();
       }

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -12,6 +12,7 @@ var url = require('url');
 var MAX_POSTS = 10;
 
 var db = require('./db').register('posts');
+var profile = require('./profile');
 
 var getTime = function () {
   return Math.floor(Date.now() / 1000);
@@ -340,39 +341,48 @@ exports.getAllByUser = function (uid, next) {
 exports.getRecent = function (request, reply) {
   var uid = request.session.get('uid');
 
-  setPagination('user!' + uid + '!', request, function (err, streamOpt) {
+  profile.getByUID(uid, function (err, user) {
     if (err) {
-      return reply(Boom.wrap(err, 400));
+      // This would mean that the user's acct has been deleted
+      // so we should just not show this page anyway.
+      return reply(Boom.wrap(err, 404));
     }
 
-    var rs = db.createReadStream(streamOpt.stream);
-
-    rs.pipe(concat(function (posts) {
-      var firstKey = false;
-      var lastKey = false;
-
-      if (posts.length) {
-        firstKey = posts[0].key;
-        lastKey = posts[posts.length - 1].key;
+    setPagination('user!' + uid + '!', request, function (err, streamOpt) {
+      if (err) {
+        return reply(Boom.wrap(err, 400));
       }
 
-      posts = posts.map(function (post) {
-        post.value.created = setDate(post.value.created);
-        return post;
-      });
+      var rs = db.createReadStream(streamOpt.stream);
 
-      return reply.view('posts', {
-        firstKey: firstKey,
-        lastKey: lastKey,
-        next: (streamOpt.finalKey !== lastKey),
-        analytics: conf.get('analytics'),
-        session: uid,
-        posts: posts
-      });
-    }));
+      rs.pipe(concat(function (posts) {
+        var firstKey = false;
+        var lastKey = false;
 
-    rs.on('error', function (err) {
-      return reply(Boom.wrap(err, 400));
+        if (posts.length) {
+          firstKey = posts[0].key;
+          lastKey = posts[posts.length - 1].key;
+        }
+
+        posts = posts.map(function (post) {
+          post.value.created = setDate(post.value.created);
+          return post;
+        });
+
+        return reply.view('posts', {
+          firstKey: firstKey,
+          lastKey: lastKey,
+          next: (streamOpt.finalKey !== lastKey),
+          analytics: conf.get('analytics'),
+          session: uid,
+          posts: posts,
+          user: user
+        });
+      }));
+
+      rs.on('error', function (err) {
+        return reply(Boom.wrap(err, 400));
+      });
     });
   });
 };

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -7,6 +7,7 @@ var conf = require('./conf');
 
 var crypto = require('crypto');
 var utils = require('./utils');
+var url = require('url');
 
 var MAX_POSTS = 10;
 
@@ -15,6 +16,43 @@ var db = require('./db').register('posts');
 var getTime = function () {
   return Math.floor(Date.now() / 1000);
 };
+
+var internalLinkRe = function () {
+  // The better to inline you with...
+  var key = '(post![0-9]+-[0-9a-f]+|user![0-9a-f-]{36}![0-9]+-[0-9a-f]+)';
+  var pattern = 'https?://[^/\\s]+/post/' + key;
+  return new RegExp(pattern);
+};
+
+// find replies that look like links to other posts in the system.
+// to be "internal" must have this hostname
+var getInternalLinks = function (reply, host) {
+  if (!host) return false;
+
+  reply = reply.trim();
+  if (!reply) return false;
+
+  var urls = reply.trim().split(/\s+/);
+
+  var internalLinks = urls.map(function (r) {
+    var parsed = r.match(internalLinkRe());
+    if (!parsed) return false;
+
+    var u = url.parse(parsed[0]);
+    if (u.host === host) {
+      // internal link.  Just save the postid.
+      return parsed[1].replace(/^(post!|user![^!]+!)(.*)$/, '$2');
+    } else {
+      console.error('not an internal link host=%j u=%j', host, u);
+    }
+
+    return false;
+  }).filter(function (r) {
+    return r;
+  });
+
+  return internalLinks;
+}
 
 exports.add = function (request, reply) {
   var time = getTime();
@@ -34,10 +72,13 @@ exports.add = function (request, reply) {
     return reply(Boom.wrap(err, 400));
   }
 
+  var host = request.headers.host;
+
   var postItem = {
     uid: uid,
     name: name,
     created: time,
+    replyto: getInternalLinks(request.payload.reply, host),
     reply: utils.autoLink(request.payload.reply) || '',
     content: utils.autoLink(request.payload.content, {
       htmlEscapeNonEntities: true,
@@ -47,18 +88,31 @@ exports.add = function (request, reply) {
 
   var postid = time + '-' + crypto.randomBytes(1).toString('hex');
 
+  var done = function (err) {
+    if (err) {
+      return reply(Boom.wrap(err, 400));
+    }
+    reply.redirect('/posts');
+  };
+
   var savePost = function () {
     db.put('user!' + request.session.get('uid') + '!' + postid, postItem, function (err) {
       if (err) {
-        return reply(Boom.wrap(err, 400));
+        return done(err);
       }
 
       db.put('post!' + postid, postItem, function (err) {
         if (err) {
-          return reply(Boom.wrap(err, 400));
+          return done(err);
         }
 
-        reply.redirect('/posts');
+        saveReply(postItem, function (err) {
+          if (err) {
+            return done(err);
+          }
+
+          reply.redirect('/posts');
+        });
       });
     });
   };
@@ -83,6 +137,44 @@ exports.add = function (request, reply) {
 
   getId();
 };
+
+var saveReply = function (postItem, next) {
+  if (!postItem.replyto) {
+    return process.nextTick(next);
+  }
+
+  var count = postItem.replyto.length;
+  if (!count) {
+    return process.nextTick(next);
+  }
+
+  var postid = postItem.postid;
+
+  postItem.replyto.forEach(function (target) {
+    // content and replies get big.  We just need a few basics.
+    // TODO(isaacs): Look up target post to make sure it's valid.
+    // TODO(isaacs): put target UID on this object for moderation privs.
+    var replyItem = {
+      uid: postItem.uid,
+      name: postItem.name,
+      created: postItem.created
+    };
+
+    db.put('replyto!' + target + '!' + postid, replyItem, function (err) {
+      then(err);
+    });
+  });
+
+  var error;
+  var then = function (err) {
+    if (err) {
+      error = err;
+    }
+    if (--count <= 0) {
+      return next(error);
+    }
+  };
+}
 
 var setDate = function (created) {
   return moment(created * 1000).format('MMM Do, YYYY - HH:mm a');
@@ -295,6 +387,7 @@ exports.getRecentForUser = function (uid, request, next) {
 };
 
 exports.del = function (request, reply) {
+  // TODO(isaacs): delete replies to and from this post.
   if (request.session && (request.session.get('uid') === request.payload.uid) || request.session.get('op')) {
     var keyArr = request.params.key.split('!');
     var time = keyArr[keyArr.length - 1];
@@ -328,12 +421,54 @@ exports.get = function (request, reply) {
 
     post.created = setDate(post.created);
 
-    reply.view('post', {
-      analytics: conf.get('analytics'),
-      id: request.params.key,
-      session: request.session.get('uid') || false,
-      op: request.session.get('op'),
-      post: post
+    getReplyPosts(post, function (err, post) {
+      if (err) {
+        return reply(Boom.wrap(err, 404));
+      }
+
+      reply.view('post', {
+        analytics: conf.get('analytics'),
+        id: request.params.key,
+        session: request.session.get('uid') || false,
+        op: request.session.get('op'),
+        post: post
+      });
     });
   });
+};
+
+// TODO(isaacs): Pagination.  Maybe only show the first 100 here,
+// but have them all in a top-level "replies" tab?
+var getReplyPosts = function (post, next) {
+  var streamOpt = {
+    gte: 'replyto!' + post.postid,
+    lte: 'replyto!' + post.postid + '\xff',
+    limit: 100
+  };
+
+  var replies = [];
+  var rs = db.createReadStream(streamOpt);
+
+  rs.on('data', function (reply) {
+    var val = reply.value;
+    var key = reply.key;
+
+    var reply = key.match(/^replyto![^!]+!([^!]+)$/);
+    if (!reply) return;
+    reply = reply[1];
+    if (!reply) return;
+
+    var html = '\n<a href="/post/post!' + reply + '" rel="nofollow">' +
+      setDate(val.created) + '</a> - ' +
+      '<a href="/user/' + val.uid + '">' + val.name + '</a>';
+
+    replies.push(html);
+  });
+
+  rs.on('end', function () {
+    post.replies = replies.join('');
+    next(null, post);
+  });
+
+  rs.on('error', next);
 };

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -387,22 +387,82 @@ exports.getRecentForUser = function (uid, request, next) {
 };
 
 exports.del = function (request, reply) {
-  // TODO(isaacs): delete replies to and from this post.
   if (request.session && (request.session.get('uid') === request.payload.uid) || request.session.get('op')) {
     var keyArr = request.params.key.split('!');
-    var time = keyArr[keyArr.length - 1];
+    var postid = keyArr[keyArr.length - 1];
 
-    db.del('post!' + time, function (err) {
+    // get the post data first.
+    db.get('post!' + postid, function (err, post) {
       if (err) {
-        return reply(Boom.wrap(err, 404));
+        return reply(Boom.wrap, err, 404);
       }
 
-      db.del('user!' + request.payload.uid + '!' + time);
-      reply.redirect('/posts');
+      if (post.uid !== request.payload.uid) {
+        return reply(Boom.wrap, new Error('forbidden'), 403);
+      }
+
+      var keys = [
+        'post!' + postid,
+        'user!' + post.uid + '!' + postid
+      ];
+
+      if (post.replyto && post.replyto.length) {
+        post.replyto.forEach(function (target) {
+          keys.push('replyto!' + target + '!' + postid);
+        });
+      }
+
+      var ks = db.createKeyStream({
+        gte: 'replyto!' + postid,
+        lte: 'replyto!' + postid + '\xff'
+      });
+
+      ks.on('data', function (key) {
+        keys.push(key);
+      });
+
+      var hadError = false;
+      ks.on('error', function (err) {
+        hadError = true;
+        reply(Boom.wrap, err, 500);
+      })
+
+      ks.on('end', function () {
+        if (hadError) {
+          return;
+        }
+        deleteKeys(keys);
+      });
     });
   } else {
     reply.redirect('/');
   }
+
+  var deleteKeys = function (keys) {
+    var len = keys.length;
+    if (len === 0) {
+      return reply.redirect('/posts');
+    }
+
+    var error = false;
+    keys.forEach(function (key) {
+      db.del(key, function (err) {
+        if (err) {
+          error = err;
+        }
+        if (--len <= 0) {
+          next(error);
+        }
+      });
+    });
+
+    var next = function (err) {
+      if (err) {
+        return reply(Boom.wrap, err, 404);
+      }
+      reply.redirect('/posts');
+    };
+  };
 };
 
 exports.get = function (request, reply) {
@@ -421,10 +481,12 @@ exports.get = function (request, reply) {
 
     post.created = setDate(post.created);
 
-    getReplyPosts(post, function (err, post) {
+    getReplyPosts(post, function (err, replies) {
       if (err) {
         return reply(Boom.wrap(err, 404));
       }
+
+      post.replies = replies;
 
       reply.view('post', {
         analytics: conf.get('analytics'),
@@ -442,11 +504,11 @@ exports.get = function (request, reply) {
 var getReplyPosts = function (post, next) {
   var streamOpt = {
     gte: 'replyto!' + post.postid,
-    lte: 'replyto!' + post.postid + '\xff',
-    limit: 100
+    lte: 'replyto!' + post.postid + '\xff'
   };
 
   var replies = [];
+  var repliesraw = [];
   var rs = db.createReadStream(streamOpt);
 
   rs.on('data', function (reply) {
@@ -458,6 +520,8 @@ var getReplyPosts = function (post, next) {
     reply = reply[1];
     if (!reply) return;
 
+    repliesraw.push(reply);
+
     var html = '\n<a href="/post/post!' + reply + '" rel="nofollow">' +
       setDate(val.created) + '</a> - ' +
       '<a href="/user/' + val.uid + '">' + val.name + '</a>';
@@ -466,8 +530,7 @@ var getReplyPosts = function (post, next) {
   });
 
   rs.on('end', function () {
-    post.replies = replies.join('');
-    next(null, post);
+    next(null, replies.join(''), repliesraw);
   });
 
   rs.on('error', next);

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -25,7 +25,8 @@ var internalLinkRe = function () {
 };
 
 // find replies that look like links to other posts in the system.
-// to be "internal" must have this hostname
+// to be "internal" must have this hostname.  If they're actually
+// valid posts, then we track stuff.  If not, then we don't bother.
 var getInternalLinks = function (reply, host) {
   if (!host) return false;
 
@@ -150,10 +151,8 @@ var saveReply = function (postItem, next) {
 
   var postid = postItem.postid;
 
-  postItem.replyto.forEach(function (target) {
+  postItem.replyto.forEach(function (target, index) {
     // content and replies get big.  We just need a few basics.
-    // TODO(isaacs): Look up target post to make sure it's valid.
-    // TODO(isaacs): put target UID on this object for moderation privs.
     // TODO(isaacs): don't create if author is muted by target author
     // TODO(isaacs): don't create if target is closed to replies
     var replyItem = {
@@ -162,8 +161,16 @@ var saveReply = function (postItem, next) {
       created: postItem.created
     };
 
-    db.put('replyto!' + target + '!' + postid, replyItem, function (err) {
-      then(err);
+    db.get('post!' + target, function (err, targetPost) {
+      if (err) {
+        // invalid replyto.  skip, and mark for deletion once we're done.
+        postItem.replyto[index] = false;
+        return then();
+      }
+
+      db.put('replyto!' + target + '!' + postid, replyItem, function (err) {
+        then(err);
+      });
     });
   });
 
@@ -172,7 +179,13 @@ var saveReply = function (postItem, next) {
     if (err) {
       error = err;
     }
+
     if (--count <= 0) {
+      // filter out any replyto entries that were invalid.
+      postItem.replyto = postItem.replyto.filter(function (rt) {
+        return rt;
+      });
+
       return next(error);
     }
   };

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -28,16 +28,22 @@ var internalLinkRe = function () {
 // to be "internal" must have this hostname.  If they're actually
 // valid posts, then we track stuff.  If not, then we don't bother.
 var getInternalLinks = function (reply, host) {
-  if (!host) return false;
+  if (!host) {
+    return false;
+  }
 
   reply = reply.trim();
-  if (!reply) return false;
+  if (!reply) {
+    return false;
+  }
 
   var urls = reply.trim().split(/\s+/);
 
   var internalLinks = urls.map(function (r) {
     var parsed = r.match(internalLinkRe());
-    if (!parsed) return false;
+    if (!parsed) {
+      return false;
+    }
 
     var u = url.parse(parsed[0]);
     if (u.host === host) {
@@ -51,7 +57,66 @@ var getInternalLinks = function (reply, host) {
   });
 
   return internalLinks;
-}
+};
+
+var saveReply = function (postItem, next) {
+  if (!postItem.replyto) {
+    return process.nextTick(next);
+  }
+
+  var count = postItem.replyto.length;
+  if (!count) {
+    return process.nextTick(next);
+  }
+
+  var postid = postItem.postid;
+
+  var error;
+  var then = function (err) {
+    if (err) {
+      error = err;
+    }
+
+    if (--count <= 0) {
+      // filter out any replyto entries that were invalid.
+      postItem.replyto = postItem.replyto.filter(function (rt) {
+        return rt;
+      });
+
+      return next(error);
+    }
+  };
+
+  postItem.replyto.forEach(function (target, index) {
+    // content and replies get big.  We just need a few basics.
+    // TODO(isaacs): don't create if author is muted by target author
+    // TODO(isaacs): don't create if target is closed to replies
+    var replyItem = {
+      uid: postItem.uid,
+      name: postItem.name,
+      created: postItem.created,
+      postid: postid,
+      target: target
+    };
+
+    db.get('post!' + target, function (err, targetPost) {
+      if (err) {
+        // invalid replyto.  skip, and mark for deletion once we're done.
+        postItem.replyto[index] = false;
+        return then();
+      }
+
+      if (!targetPost.showreplies) {
+        postItem.replyto[index] = false;
+        return then();
+      }
+
+      db.put('replyto!' + target + '!' + postid, replyItem, function (err) {
+        then(err);
+      });
+    });
+  });
+};
 
 exports.add = function (request, reply) {
   var time = getTime();
@@ -137,65 +202,6 @@ exports.add = function (request, reply) {
 
   getId();
 };
-
-var saveReply = function (postItem, next) {
-  if (!postItem.replyto) {
-    return process.nextTick(next);
-  }
-
-  var count = postItem.replyto.length;
-  if (!count) {
-    return process.nextTick(next);
-  }
-
-  var postid = postItem.postid;
-
-  postItem.replyto.forEach(function (target, index) {
-    // content and replies get big.  We just need a few basics.
-    // TODO(isaacs): don't create if author is muted by target author
-    // TODO(isaacs): don't create if target is closed to replies
-    var replyItem = {
-      uid: postItem.uid,
-      name: postItem.name,
-      created: postItem.created,
-      postid: postid,
-      target: target
-    };
-
-    db.get('post!' + target, function (err, targetPost) {
-      if (err) {
-        // invalid replyto.  skip, and mark for deletion once we're done.
-        postItem.replyto[index] = false;
-        return then();
-      }
-
-      if (!targetPost.showreplies) {
-        postItem.replyto[index] = false;
-        return then();
-      }
-
-      db.put('replyto!' + target + '!' + postid, replyItem, function (err) {
-        then(err);
-      });
-    });
-  });
-
-  var error;
-  var then = function (err) {
-    if (err) {
-      error = err;
-    }
-
-    if (--count <= 0) {
-      // filter out any replyto entries that were invalid.
-      postItem.replyto = postItem.replyto.filter(function (rt) {
-        return rt;
-      });
-
-      return next(error);
-    }
-  };
-}
 
 var setDate = function (created) {
   return moment(created * 1000).format('MMM Do, YYYY - HH:mm a');
@@ -445,6 +451,32 @@ exports.delReply = function (request, reply) {
 
 exports.del = function (request, reply) {
   if (request.session && (request.session.get('uid') === request.payload.uid) || request.session.get('op')) {
+    var deleteKeys = function (keys) {
+      var len = keys.length;
+      if (len === 0) {
+        return reply.redirect('/posts');
+      }
+
+      var next = function (err) {
+        if (err) {
+          return reply(Boom.wrap, err, 404);
+        }
+        reply.redirect('/posts');
+      };
+
+      var error = false;
+      keys.forEach(function (key) {
+        db.del(key, function (err) {
+          if (err) {
+            error = err;
+          }
+          if (--len <= 0) {
+            next(error);
+          }
+        });
+      });
+    };
+
     var keyArr = request.params.key.split('!');
     var postid = keyArr[keyArr.length - 1];
 
@@ -482,7 +514,7 @@ exports.del = function (request, reply) {
       ks.on('error', function (err) {
         hadError = true;
         reply(Boom.wrap, err, 500);
-      })
+      });
 
       ks.on('end', function () {
         if (hadError) {
@@ -494,32 +526,40 @@ exports.del = function (request, reply) {
   } else {
     reply.redirect('/');
   }
+};
 
-  var deleteKeys = function (keys) {
-    var len = keys.length;
-    if (len === 0) {
-      return reply.redirect('/posts');
+// TODO(isaacs): Pagination.  Maybe only show the first 100 here,
+// but have them all in a top-level "replies" tab?
+var getReplyPosts = function (post, next) {
+  var streamOpt = {
+    gte: 'replyto!' + post.postid,
+    lte: 'replyto!' + post.postid + '\xff'
+  };
+
+  var replies = [];
+  var rs = db.createReadStream(streamOpt);
+
+  rs.on('data', function (reply) {
+    var val = reply.value;
+    var key = reply.key;
+
+    var replyid = key.match(/^replyto![^!]+!([^!]+)$/);
+    if (!replyid) {
+      return;
+    }
+    replyid = replyid[1];
+    if (!replyid) {
+      return;
     }
 
-    var error = false;
-    keys.forEach(function (key) {
-      db.del(key, function (err) {
-        if (err) {
-          error = err;
-        }
-        if (--len <= 0) {
-          next(error);
-        }
-      });
-    });
+    replies.push(val);
+  });
 
-    var next = function (err) {
-      if (err) {
-        return reply(Boom.wrap, err, 404);
-      }
-      reply.redirect('/posts');
-    };
-  };
+  rs.on('end', function () {
+    next(null, replies);
+  });
+
+  rs.on('error', next);
 };
 
 exports.get = function (request, reply) {
@@ -557,34 +597,4 @@ exports.get = function (request, reply) {
       });
     });
   });
-};
-
-// TODO(isaacs): Pagination.  Maybe only show the first 100 here,
-// but have them all in a top-level "replies" tab?
-var getReplyPosts = function (post, next) {
-  var streamOpt = {
-    gte: 'replyto!' + post.postid,
-    lte: 'replyto!' + post.postid + '\xff'
-  };
-
-  var replies = [];
-  var rs = db.createReadStream(streamOpt);
-
-  rs.on('data', function (reply) {
-    var val = reply.value;
-    var key = reply.key;
-
-    var reply = key.match(/^replyto![^!]+!([^!]+)$/);
-    if (!reply) return;
-    reply = reply[1];
-    if (!reply) return;
-
-    replies.push(val);
-  });
-
-  rs.on('end', function () {
-    next(null, replies);
-  });
-
-  rs.on('error', next);
 };

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -401,6 +401,42 @@ exports.getRecentForUser = function (uid, request, next) {
   });
 };
 
+exports.delReply = function (request, reply) {
+  if (request.session && (request.session.get('uid') === request.payload.uid) || request.session.get('op')) {
+    var uid = request.payload.uid;
+    var op = request.session.get('op');
+
+    var key = request.params.key;
+    var keyArr = key.split('!');
+    if (keyArr[0] !== 'replyto') {
+      return reply(Boom.wrap, new Error('not found'), 404);
+    }
+
+    var target = keyArr[1];
+
+    // verify that either the user is an op, or is the owner
+    // of the target post.
+    db.get('post!' + target, function (err, postItem) {
+      if (err) {
+        return reply(Boom.wrap, err, 404);
+      }
+
+      if (!op && postItem.uid !== uid) {
+        return reply(Boom.wrap, new Error('forbidden'), 403);
+      }
+
+      db.del(key, function (err) {
+        if (err) {
+          return reply(Boom.wrap, err, 400);
+        }
+        reply.redirect('/post/post!' + target);
+      });
+    });
+  } else {
+    reply.redirect('/');
+  }
+};
+
 exports.del = function (request, reply) {
   if (request.session && (request.session.get('uid') === request.payload.uid) || request.session.get('op')) {
     var keyArr = request.params.key.split('!');

--- a/lib/profile.js
+++ b/lib/profile.js
@@ -35,6 +35,7 @@ exports.update = function (request, reply) {
       name: name,
       websites: request.payload.websites,
       bio: request.payload.bio,
+      showreplies: request.payload.showreplies === 'on',
       phone: phone
     };
 

--- a/lib/profile.js
+++ b/lib/profile.js
@@ -304,6 +304,9 @@ exports.exportPosts = function (request, reply) {
       if (!post.value.postid) {
         post.value.postid = String(post.value.created);
       }
+      // Manual CSV encoding doesn't handle arrays or booleans
+      delete post.value.replyto;
+      delete post.value.showreplies;
       return post.value;
     });
 

--- a/public/styl/global.styl
+++ b/public/styl/global.styl
@@ -130,6 +130,11 @@ input, textarea {
   width: 100%;
 }
 
+input[type=checkbox] {
+  display: inline;
+  width: auto;
+}
+
 form {
   max-width: 408px;
   margin-bottom: 20px;

--- a/public/styl/global.styl
+++ b/public/styl/global.styl
@@ -425,6 +425,25 @@ article .posted {
   font-size: 1.3rem;
 }
 
+.moderate {
+  display: inline;
+  background: none;
+  padding: 0;
+  margin: 0;
+}
+
+.moderate button {
+  width: auto;
+  padding: 0;
+  margin: 0;
+  line-height: 1;
+  height: auto;
+  display: inline;
+  background: none;
+  color: red;
+  font-size: inherit;
+}
+
 .pagination {
   border-top: 1px solid #eee;
   margin: 30px 0;

--- a/public/styl/global.styl
+++ b/public/styl/global.styl
@@ -434,6 +434,7 @@ article .posted {
 .content article p.reply {
   font-style: italic;
   margin-bottom: 0;
+  margin-top: 15px;
 }
 
 .delete-account {

--- a/test/test.js
+++ b/test/test.js
@@ -300,7 +300,9 @@ lab.test('make a response post', function (done) {
       cookie: cookieHeader()
     },
     payload: {
-      reply: 'http://' + HOST  + '/post/post!' + post,
+      reply: 'http://' + HOST + '/post/post!' + post + ' ' +
+             // this isn't a valid link
+             'http://' + HOST + '/post/post!12345-ab',
       content: 'Reply forthwith',
       fuzziewuzzywasabear: 'some fuzes fore goode measuries'
     }
@@ -422,6 +424,20 @@ lab.test('verify reply links to post', function (done) {
     var match = replies.match(re);
     Code.expect(match[1]).to.equal(post);
     done();
+  });
+});
+
+lab.test('invalid reply post id not stored', function (done) {
+  var postdb = db('posts');
+  postdb.get('replyto!12345-ab!' + replypost, function (err, replyItem) {
+    // should get an error, and no replyItem here.
+    Code.expect(!!err).to.equal(true);
+    Code.expect(!!replyItem).to.equal(false);
+    postdb.get('replyto!' + post + '!' + replypost, function (err, replyItem) {
+      Code.expect(!!err).to.equal(false);
+      Code.expect(!!replyItem).to.equal(true);
+      done();
+    });
   });
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -465,7 +465,7 @@ lab.test('verify that replies section is gone', function (done) {
 
     // should not contain a 'replies' section any more.
     var replies = response.payload.split('replies:');
-    Code.expect(replies.length).to.equal(2);
+    Code.expect(replies.length).to.equal(1);
     done();
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -241,7 +241,7 @@ lab.test('create new post with session and name', function (done) {
     payload: {
       reply: '',
       content: 'Ye olde goode poste',
-      showreply: 'on',
+      showreplies: 'on',
       fuzze: 'some fuzes fore goode measuries'
     }
   };
@@ -365,7 +365,7 @@ lab.test('make a response post', function (done) {
              // this doesn't track replies
              'http://' + HOST + '/post/post!' + noreplypost,
       content: 'Reply forthwith',
-      showreply: 'on',
+      showreplies: 'on',
       fuzziewuzzywasabear: 'some fuzes fore goode measuries'
     }
   };
@@ -569,7 +569,7 @@ lab.test('create another reply', function (done) {
              // this isn't a valid link
              'http://' + HOST + '/post/post!12345-ab',
       content: 'replyparttwo',
-      showreply: 'on',
+      showreplies: 'on',
       fuzziewuzzywasabear: 'some fuzes fore goode measuries'
     }
   };
@@ -724,7 +724,7 @@ lab.test('post page defaults to showing replies', function (done) {
   server.inject(options, function (response) {
     saveCookies(response);
 
-    var pattern = '<input type="checkbox" name="showreply" checked>';
+    var pattern = '<input type="checkbox" name="showreplies" checked>';
     Code.expect(response.payload).to.match(new RegExp(pattern));
     done();
   });
@@ -767,7 +767,7 @@ lab.test('post page defaults to not showing replies', function (done) {
   server.inject(options, function (response) {
     saveCookies(response);
 
-    var pattern = '<input type="checkbox" name="showreply">';
+    var pattern = '<input type="checkbox" name="showreplies">';
     Code.expect(response.payload).to.match(new RegExp(pattern));
     done();
   });

--- a/test/test.js
+++ b/test/test.js
@@ -40,7 +40,6 @@ var resetDB = function () {
 // or else leveldb will freak out.
 resetDB();
 
-
 var db = require('../lib/db');
 
 var Lab = require('lab');
@@ -74,7 +73,6 @@ var cookieHeader = function () {
   }).join(',');
   return ch;
 };
-
 
 // once tests are done, delete test db.
 lab.after(function (done) {
@@ -132,7 +130,6 @@ lab.test('unsuccessful authentication by multiple login attempts', function (don
   postLogin();
 });
 
-
 lab.test('log in with valid pin', function (done) {
   var options = {
     method: 'POST',
@@ -152,7 +149,6 @@ lab.test('log in with valid pin', function (done) {
     done();
   });
 });
-
 
 lab.test('authenticate with an invalid PIN', function (done) {
   var options = {
@@ -258,7 +254,6 @@ lab.test('create new post with session and name', function (done) {
   });
 });
 
-
 var uid, post, noreplypost, replypost;
 var getArticle = function (payload, snippet) {
   payload = payload.replace(/\n/g, ' ');
@@ -277,7 +272,6 @@ var getPostID = function (payload, snippet) {
   var postid = article.match(new RegExp('href="/post/post!([^"]+)"'))[1];
   return postid;
 };
-
 
 lab.test('verify post on /discover', function (done) {
   var options = {
@@ -312,7 +306,6 @@ lab.test('verify post on /discover', function (done) {
   });
 });
 
-
 lab.test('create post that doesnt show replies', function (done) {
   var options = {
     method: 'POST',
@@ -336,7 +329,6 @@ lab.test('create post that doesnt show replies', function (done) {
   });
 });
 
-
 lab.test('verify post on /discover', function (done) {
   var options = {
     method: 'GET',
@@ -358,8 +350,6 @@ lab.test('verify post on /discover', function (done) {
     done();
   });
 });
-
-
 
 lab.test('make a response post', function (done) {
   var options = {
@@ -387,7 +377,6 @@ lab.test('make a response post', function (done) {
     done();
   });
 });
-
 
 lab.test('verify post on /discover', function (done) {
   var options = {
@@ -450,7 +439,6 @@ lab.test('get csv export of posts', function (done) {
   });
 });
 
-
 lab.test('verify post shows reply', function (done) {
   var options = {
     method: 'GET',
@@ -488,7 +476,6 @@ lab.test('verify post shows reply', function (done) {
   });
 });
 
-
 lab.test('verify norelply post does not show reply', function (done) {
   var options = {
     method: 'GET',
@@ -510,7 +497,6 @@ lab.test('verify norelply post does not show reply', function (done) {
     done();
   });
 });
-
 
 lab.test('verify reply links to post', function (done) {
   var options = {
@@ -536,7 +522,6 @@ lab.test('verify reply links to post', function (done) {
   });
 });
 
-
 lab.test('invalid reply post id not stored, valid should be', function (done) {
   var postdb = db('posts');
   postdb.get('replyto!12345-ab!' + replypost, function (err, replyItem) {
@@ -550,7 +535,6 @@ lab.test('invalid reply post id not stored, valid should be', function (done) {
     });
   });
 });
-
 
 lab.test('delete replypost', function (done) {
   var options = {
@@ -572,7 +556,6 @@ lab.test('delete replypost', function (done) {
     done();
   });
 });
-
 
 lab.test('create another reply', function (done) {
   var options = {
@@ -619,7 +602,6 @@ lab.test('verify post on /discover', function (done) {
   });
 });
 
-
 lab.test('verify post shows second reply', function (done) {
   var options = {
     method: 'GET',
@@ -645,7 +627,6 @@ lab.test('verify post shows second reply', function (done) {
   });
 });
 
-
 lab.test('use the moderation form to delete second reply', function (done) {
   var options = {
     method: 'POST',
@@ -665,7 +646,6 @@ lab.test('use the moderation form to delete second reply', function (done) {
     done();
   });
 });
-
 
 lab.test('verify that replies section is gone', function (done) {
   var options = {
@@ -689,7 +669,6 @@ lab.test('verify that replies section is gone', function (done) {
   });
 });
 
-
 lab.test('post link redirect to canonical post url', function (done) {
   var options = {
     method: 'GET',
@@ -704,6 +683,92 @@ lab.test('post link redirect to canonical post url', function (done) {
 
     Code.expect(response.statusCode).to.equal(301);
     Code.expect(response.headers.location).to.equal('/post/post!' + post);
+    done();
+  });
+});
+
+lab.test('set showreplies in profile', function (done) {
+  var options = {
+    method: 'POST',
+    url: 'http://' + HOST + '/profile',
+    payload: {
+      name: 'Mx. Test',
+      websites: 'http://bigboringsystem.com https://x.y.z',
+      bio: 'Just a test account',
+      showreplies: 'on'
+    },
+    headers: {
+      cookie: cookieHeader()
+    }
+  };
+
+  server.inject(options, function (response) {
+    saveCookies(response);
+
+    Code.expect(response.statusCode).to.equal(200);
+    var pattern = '<input type="checkbox" name="showreplies" checked>';
+    Code.expect(response.payload).to.match(new RegExp(pattern));
+    done()
+  });
+});
+
+lab.test('post page defaults to showing replies', function (done) {
+  var options = {
+    method: 'GET',
+    url: 'http://' + HOST + '/posts',
+    headers: {
+      cookie: cookieHeader()
+    }
+  };
+
+  server.inject(options, function (response) {
+    saveCookies(response);
+
+    var pattern = '<input type="checkbox" name="showreply" checked>';
+    Code.expect(response.payload).to.match(new RegExp(pattern));
+    done();
+  });
+});
+
+lab.test('set showreplies to false in profile', function (done) {
+  var options = {
+    method: 'POST',
+    url: 'http://' + HOST + '/profile',
+    payload: {
+      name: 'Mx. Test',
+      websites: 'http://bigboringsystem.com https://x.y.z',
+      bio: 'Just a test account',
+      showreplies: 'this is not a valid value so it unchecks'
+    },
+    headers: {
+      cookie: cookieHeader()
+    }
+  };
+
+  server.inject(options, function (response) {
+    saveCookies(response);
+
+    Code.expect(response.statusCode).to.equal(200);
+    var pattern = '<input type="checkbox" name="showreplies">';
+    Code.expect(response.payload).to.match(new RegExp(pattern));
+    done()
+  });
+});
+
+lab.test('post page defaults to not showing replies', function (done) {
+  var options = {
+    method: 'GET',
+    url: 'http://' + HOST + '/posts',
+    headers: {
+      cookie: cookieHeader()
+    }
+  };
+
+  server.inject(options, function (response) {
+    saveCookies(response);
+
+    var pattern = '<input type="checkbox" name="showreply">';
+    Code.expect(response.payload).to.match(new RegExp(pattern));
     done();
   });
 });

--- a/views/post.jade
+++ b/views/post.jade
@@ -16,4 +16,8 @@ block content
     pre!= post.content
     div.reply-to-post
       a(href='/posts?reply_to=#{id}') Reply to this post
+    if post.replies
+      p.reply replies:
+        != post.replies
+
 block login

--- a/views/post.jade
+++ b/views/post.jade
@@ -10,14 +10,26 @@ block content
     a(href='/user/#{post.uid}')= post.name
   article
     time= post.created
+
     if post.reply
       p.reply in reply to:&#xa0;
         != post.reply
+
     pre!= post.content
     div.reply-to-post
       a(href='/posts?reply_to=#{id}') Reply to this post
-    if post.replies
+
+    if post.replies && post.replies.length
       p.reply replies:
-        != post.replies
+      for reply in post.replies
+        if session && (session === post.uid || op)
+          form(method='POST', action='/reply/replyto!#{reply.target}!#{reply.postid}' class='moderate')
+            input(type='hidden', name='uid', value='#{post.uid}')
+            input(type='hidden', name='crumb', value='#{crumb}')
+            button(type='submit') X
+        a(href='/post/post!#{reply.postid}')= reply.created
+        = ' - '
+        a(href='/user/#{reply.uid}')= reply.name
+        br
 
 block login

--- a/views/posts.jade
+++ b/views/posts.jade
@@ -4,9 +4,9 @@ block content
   h1 my posts
 
   form(method='post', action='/post')
-    label(for='reply') reply links to previous posts? (space delimited)
+    label reply links to previous posts? (space delimited)
       input#reply-to(type='text', name='reply')
-    label(for='content') content
+    label content
       textarea(rows='10', cols='90', name='content', required)
     if error
       p.error= error

--- a/views/posts.jade
+++ b/views/posts.jade
@@ -8,6 +8,9 @@ block content
       input#reply-to(type='text', name='reply')
     label content
       textarea(rows='10', cols='90', name='content', required)
+    label
+      input(type='checkbox', name='showreply')
+      = 'show replies to this post'
     if error
       p.error= error
     input(type='hidden', name='crumb', value='#{crumb}')

--- a/views/posts.jade
+++ b/views/posts.jade
@@ -10,9 +10,9 @@ block content
       textarea(rows='10', cols='90', name='content', required)
     label
       if user.showreplies
-        input(type='checkbox', name='showreply', checked)
+        input(type='checkbox', name='showreplies', checked)
       else
-        input(type='checkbox', name='showreply')
+        input(type='checkbox', name='showreplies')
       = 'show replies to this post'
     if error
       p.error= error

--- a/views/posts.jade
+++ b/views/posts.jade
@@ -9,7 +9,10 @@ block content
     label content
       textarea(rows='10', cols='90', name='content', required)
     label
-      input(type='checkbox', name='showreply')
+      if user.showreplies
+        input(type='checkbox', name='showreply', checked)
+      else
+        input(type='checkbox', name='showreply')
       = 'show replies to this post'
     if error
       p.error= error

--- a/views/profile.jade
+++ b/views/profile.jade
@@ -8,20 +8,20 @@ block content
   form(method='post', action='/profile')
     if error
       p.error= error
-    label(for='name') name*
+    label name*
       input(type='text', name='name', value='#{user && user.name ? user.name : ""}', required)
-    label(for='websites') websites (space delimited)
+    label websites (space delimited)
       input(type='text', name='websites', value='#{user && user.websites ? user.websites : ""}')
-    label(for='bio') bio
+    label bio
       textarea(rows='5', cols='50', name='bio')= (user && user.bio ? user.bio : "")
     input(type='hidden', name='crumb', value='#{crumb}')
     button(type='submit') save
 
   form(method='post', action='/add_phone')
-    label(for='phone') add a second phone number to this account
+    label add a second phone number to this account
       input(type='tel', name='phone', value='#{phone}')
     if phone
-      label(for='pin') enter the PIN sent to your secondary phone for validation
+      label enter the PIN sent to your secondary phone for validation
         input(type='text', name='pin')
     input(type='hidden', name='crumb', value='#{crumb}')
     button(type='submit') add

--- a/views/profile.jade
+++ b/views/profile.jade
@@ -14,6 +14,12 @@ block content
       input(type='text', name='websites', value='#{user && user.websites ? user.websites : ""}')
     label bio
       textarea(rows='5', cols='50', name='bio')= (user && user.bio ? user.bio : "")
+    label
+      if user && user.showreplies
+        input(type='checkbox', name='showreplies', checked)
+      else
+        input(type='checkbox', name='showreplies')
+      = 'show replies to posts by default'
     input(type='hidden', name='crumb', value='#{crumb}')
     button(type='submit') save
 


### PR DESCRIPTION
This has come along to a point where I think it's worth discussing.

This adds basic reply tracking, and puts very minimal links to in-system replies under each post.

You can choose to track replies on a per-post level.  The `showreplies` field defaults based on a profile setting.  (Default is "do not track replies by default".)

The author can delete the reply links from their posts if they want them gone.  (Of course, you can't *change* the reply-tracking behavior of a post without deleting and re-posting, since this would be an edit, and thus verboten.)

I'd like to also add the ability to block reply links from specific users.  However, I think that would be better approached as part of a larger "hide this user from me" feature.

No data migration required.  All existing posts will not track replies, since `undefined` is falsey.