### PR TITLE
showreplies added on new user creation #140

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -22,6 +22,7 @@ var addNewUser = function (uid, phone, request, reply) {
     profdb.put('user!' + phone, {
       uid: uid,
       phone: phone,
+      showreplies: true,
       secondary: {}
     }, function (err) {
       if (err) {

--- a/test/test.js
+++ b/test/test.js
@@ -210,6 +210,24 @@ lab.test('create new post without a session', function (done) {
   });
 });
 
+lab.test('profile page defaults to showing replies', function (done) {
+  var options = {
+    method: 'GET',
+    url: 'http://' + HOST + '/profile',
+    headers: {
+      cookie: cookieHeader()
+    }
+  };
+
+  server.inject(options, function (response) {
+    saveCookies(response);
+    var pattern = '<input type="checkbox" name="showreplies" checked>';
+    Code.expect(response.statusCode).to.equal(200);
+    Code.expect(response.payload).to.match(new RegExp(pattern));
+    done();
+  });
+});
+
 lab.test('add name to profile', function (done) {
   var options = {
     method: 'POST',


### PR DESCRIPTION
when a new user gets created make show replies the default so that the check boxes are checked on both profile and posts page