### PR TITLE
Fix 404 when invalid op id provided in local.json

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -24,11 +24,8 @@ exports.home = function (request, reply) {
 
     ctx.ops.forEach(function (op) {
       profile.getByUID(op, function (err, user) {
-        if (err) {
-          return reply(Boom.wrap(err, 404));
-        }
         count++;
-        if (user) {
+        if (!err && user) {
           users[op] = {
             uid: op,
             name: user.name


### PR DESCRIPTION
Fixes #144.  If a UID is provided in the package.json that does not exist in the db the app would 404 on the main page.  This is no longer the case, the op with the invalid UID is just ignored