### PR TITLE
Unescape name when displaying it back in the profile form

### DIFF
--- a/views/profile.jade
+++ b/views/profile.jade
@@ -9,7 +9,7 @@ block content
     if error
       p.error= error
     label name*
-      input(type='text', name='name', value='#{user && user.name ? user.name : ""}', required)
+      input(type='text', name='name', value!='#{user && user.name ? user.name : ""}', required)
     label websites (space delimited)
       input(type='text', name='websites', value='#{user && user.websites ? user.websites : ""}')
     label bio


### PR DESCRIPTION
This is a fix for #154. Now that names are stored in escaped form they need to be unescaped before use inside an attribute. This change uses Jade's `!=` attribute unescape syntax to do that.

Before:

1. Change name in profile to `~~` and save. Note name is displayed in the escaped form, `&#x7e;&#x7e;`.
2. Save again without making changes. The escaped entity is then escaped again.

With change:

The name is displayed as `~~` after save. Subsequent saves do not go into an escaping spiral of doom.