### PR TITLE
Check for duplicate socket UIDs on chat disconnect

### DIFF
--- a/index.js
+++ b/index.js
@@ -359,9 +359,15 @@ server.start(function (err) {
 
     socket.on('disconnect', function () {
       console.log('disconnected')
-      delete chatUsers[socket.uid];
-      chatUserCount --;
 
+      var userStillConnected = io.sockets.sockets.reduce(function(memo, sock) {
+        return memo || sock.uid === socket.uid;
+      }, false);
+      if (!userStillConnected) {
+        delete chatUsers[socket.uid];
+      }
+
+      chatUserCount --;
       if (chatUserCount < 0) {
         chatUserCount = 0;
       }


### PR DESCRIPTION
Loop through remaining open sockets when a user disconnects from chat. If a socket with the same user UID as the disconnecting socket is found, do not remove that user from the chat list. This means the user has another tab/window with chat open.

Fixes #160.