### PR TITLE
Add phoneSalt config and phone hashing utility function

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -15,7 +15,6 @@ var bandb = dbs('bans');
 var utils = require('./utils');
 
 var addNewUser = function (uid, phone, request, reply) {
-  phone = phone; // TODO: hash phone #
   profdb.put('uid!' + uid, phone, function (err) {
     if (err) {
       return reply(Boom.wrap(err, 400));
@@ -32,6 +31,7 @@ var addNewUser = function (uid, phone, request, reply) {
       }
 
       request.session.set('uid', uid);
+      request.session.set('phone', phone);
       reply.redirect('/');
     });
   });
@@ -47,7 +47,7 @@ var checkAdmin = function (uid, request) {
 var register = function (request, reply) {
   // phone number has to stay pre-hashed at this point
   var prehashPhone = utils.fixNumber(request.session.get('phone'));
-  var phone = prehashPhone; // TODO: hash phone #
+  var phone = utils.phoneHash(prehashPhone);
 
   if (process.env.NODE_ENV === 'test') {
     phone = fixtures.phone;
@@ -93,7 +93,7 @@ var register = function (request, reply) {
 
 exports.login = function (request, reply) {
   var prehashPhone = request.payload.phone;
-  var phone = prehashPhone; // TODO: hash phone #
+  var phone = utils.phoneHash(prehashPhone);
   var ip = request.info.remoteAddress;
 
   if (!ip) {

--- a/lib/profile.js
+++ b/lib/profile.js
@@ -212,10 +212,10 @@ exports.deleteAccount = function (request, reply) {
 };
 
 exports.addPhone = function (request, reply) {
-  var prehashPhone = request.payload.phone;
-  var phone = prehashPhone; // TODO: hash phone #
+  var prehashPhone = utils.fixNumber(request.payload.phone);
+  var phone = utils.phoneHash(prehashPhone);
 
-  if (parseInt(phone, 10) === parseInt(request.session.get('phone'), 10)) {
+  if (phone === request.session.get('phone')) {
     return reply(Boom.wrap(new Error('You can\'t register your primary phone as your secondary'), 400));
   }
 
@@ -232,7 +232,10 @@ exports.addPhone = function (request, reply) {
           return reply(Boom.wrap(err, 500));
         }
 
-        user.secondary[phone] = phone;
+        user.secondary[phone] = {
+          phone: phone,
+          lastTwo: prehashPhone.slice(-2)
+        };
 
         db.put('user!' + request.session.get('phone'), user, function (err) {
           if (err) {
@@ -260,7 +263,7 @@ exports.addPhone = function (request, reply) {
 
           var ctx = {
             analytics: conf.get('analytics'),
-            phone: phone,
+            phone: prehashPhone,
             user: user
           };
 
@@ -283,7 +286,7 @@ exports.addPhone = function (request, reply) {
     if (err) {
       return linkNumber();
     } else {
-      return reply(Boom.wrap(new Error('This number is already linked: ' + phone), 400));
+      return reply(Boom.wrap(new Error('This number is already linked: ' + prehashPhone), 400));
     }
   });
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var crypto = require('crypto');
+var conf = require('../lib/conf');
 var twitter = require('twitter-text');
 var concat = require('concat-stream');
 var Boom = require('boom');
@@ -56,4 +58,9 @@ exports.fixNumber = function (phone) {
   }
 
   return phone;
+};
+
+exports.phoneHash = function (phone) {
+  var salt = conf.get('phoneSalt') || 'default';
+  return crypto.createHash('sha1').update(salt + phone).digest('hex');
 };

--- a/local.json-dist
+++ b/local.json-dist
@@ -7,5 +7,6 @@
     "twilioToken": "<auth token>",
     "twilioNumber": "15555555555",
     "ops": [],
-    "db": "./db"
+    "db": "./db",
+    "phoneSalt": "<make me a random string>"
 }

--- a/scripts/hash-phone-numbers.js
+++ b/scripts/hash-phone-numbers.js
@@ -1,0 +1,40 @@
+var server = require('../index');
+var concat = require('concat-stream');
+
+var dbs = require('../lib/db');
+var profiledb = dbs('profile');
+var utils = require('../lib/utils');
+var posts = require('../lib/posts');
+
+var rs = profiledb.createReadStream({
+  gte: 'user!',
+  lte: 'user!\xff'
+});
+
+rs.pipe(concat(function (users) {
+  console.log('starting count: ', users.length)
+  var count = 0;
+  users.forEach(function (user) {
+    var userData = user.value;
+
+    // if +1 doesn't exist, make it exist
+    var updatedPhone = utils.phoneHash(userData.phone);
+    if (updatedPhone !== userData.phone) {
+      count ++;
+      userData.phone = updatedPhone;
+
+      // save new record
+      profiledb.put('user!' + updatedPhone, userData);
+      profiledb.put('uid!' + userData.uid, updatedPhone);
+
+      // delete old records
+      profiledb.del(user.key);
+    }
+  });
+
+  console.log('ending count: ', count);
+}));
+
+rs.on('error', function (err) {
+  throw err;
+});

--- a/views/profile.jade
+++ b/views/profile.jade
@@ -35,7 +35,7 @@ block content
   h2 secondary numbers
 
   for number in user.secondary
-    p= user.secondary[number]
+    p ********#{number.lastTwo}
 
   h2 export posts
 


### PR DESCRIPTION
For use in our migration scripts and future phone hashings. Adds `phoneSalt` to config file.

This also now includes commits to hash the primary phone numbers, as well as hash the secondary phone numbers + store the last 2 digits for display purposes.