### PR TITLE
Fast focusing on the chat input

### DIFF
--- a/views/chat.jade
+++ b/views/chat.jade
@@ -8,7 +8,7 @@ block content
   #chat
 
   form(method='post', id='chat-form')
-    input(type='text', id='message', name='message', autocomplete='off' autofocus)
+    input(type='text', id='message', name='message', autocomplete='off', autofocus, tabindex='1')
     button(type='submit', id='send-message') Send
 
 block footer


### PR DESCRIPTION
For if you're switching around tabs, because autofocus only applies on the initial render.