### PR TITLE
Use textContent instead of innerText for setting date strings

### DIFF
--- a/public/js/global.js
+++ b/public/js/global.js
@@ -35,7 +35,7 @@
 
   if (timeEls !== null) {
     [].forEach.call(timeEls, function (timeEl) {
-      timeEl.innerText = localDate(timeEl.getAttribute('datetime'));
+      timeEl.textContent = localDate(timeEl.getAttribute('datetime'));
     });
   }
 })();


### PR DESCRIPTION
Fixes #195 where Firefox wasn't getting date formatting. `innerText` is non-standard.