### PR TITLE
Fix missing context in privacy view rendering

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -132,7 +132,7 @@ exports.profile = function (request, reply) {
 };
 
 exports.privacy = function(request, reply) {
-    reply.view('privacy');
+    reply.view('privacy', ctx);
 };
 
 exports.noNewAccounts = function(request, reply) {


### PR DESCRIPTION
Fixes #214. Every view requires a context object, event if it's empty.