### PR TITLE
Show full username in chat on hover in sidebar

### DIFF
--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -114,7 +114,7 @@
 
     for (var user in data) {
       var li = document.createElement('li');
-      var userItem = '<a href="/user/' + user + '" target="_blank">' + data[user] + '</a>';
+      var userItem = '<a href="/user/' + user + '" target="_blank"' + 'title="' + data[user] + '">' + data[user] + '</a>';
       li.innerHTML = userItem;
       userList.appendChild(li);
     }


### PR DESCRIPTION
Many people have really long usernames with emoticons in them. This just shows the full username when you hover over their name in the sidebar.