### PR TITLE
Update stylus

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lab": "~5.1.1",
     "nodemon": "~1.2.1",
     "rimraf": "^2.2.8",
-    "stylus": "LearnBoost/stylus#7bc13e1b566a9ac2a717a2b6f9cc188855277fdf"
+    "stylus": "LearnBoost/stylus#afad71c3f895a9cdf25fc2ae010586d40e74be2d"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Latest stylus commit fixes incorrect filename inside a compiled css's sourcemap comment when a custom output file is specified. With the version currently being used, the sourcemap comment contains ```sourceMappingURL=main.css.map``` resulting in file not found errors in the browser... and no mapping.